### PR TITLE
input: fix enabling/disabling single joycon mode on Switch

### DIFF
--- a/source/c2dui_ui_main.cpp
+++ b/source/c2dui_ui_main.cpp
@@ -184,11 +184,35 @@ void UIMain::updateInputMapping(bool isRomConfig) {
 
 #ifdef __SWITCH__
     int single_joy = config->get(Option::Index::JOY_SINGLEJOYCON)->getValueBool();
-    for (int i = 0; i < PLAYER_MAX; i++) {
+    if (!hidGetHandheldMode()) {
         if (single_joy > 0) {
-            hidSetNpadJoyAssignmentModeSingleByDefault((HidControllerID) i);
+            for (int id = 0; id < 8; id++) {
+                hidSetNpadJoyAssignmentModeSingleByDefault((HidControllerID) id);
+            }
+            hidSetNpadJoyHoldType(HidJoyHoldType_Horizontal);
+            hidScanInput();
         } else {
-            hidSetNpadJoyAssignmentModeDual((HidControllerID) i);
+            // find all left/right single JoyCon pairs and join them together
+            for (int id = 0; id < 8; id++) {
+                hidSetNpadJoyAssignmentModeDual((HidControllerID) id);
+            }
+            int lastRightId = 8;
+            for (int id0 = 0; id0 < 8; id0++) {
+                if (hidGetControllerType((HidControllerID) id0) & TYPE_JOYCON_LEFT) {
+                    for (int id1 = lastRightId - 1; id1 >= 0; id1--) {
+                        if (hidGetControllerType((HidControllerID) id1) & TYPE_JOYCON_RIGHT) {
+                            lastRightId = id1;
+                            // prevent missing player numbers
+                            if (id0 < id1) {
+                                hidMergeSingleJoyAsDualJoy((HidControllerID) id0, (HidControllerID) id1);
+                            } else if (id0 > id1) {
+                                hidMergeSingleJoyAsDualJoy((HidControllerID) id1, (HidControllerID) id0);
+                            }
+                            break;
+                        }
+                    }
+                }
+            }
         }
     }
 #endif

--- a/source/c2dui_ui_menu.cpp
+++ b/source/c2dui_ui_menu.cpp
@@ -341,11 +341,35 @@ bool UIMenu::onInput(c2d::Input::Player *players) {
                     break;
 #ifdef __SWITCH__
                 case Option::Index::JOY_SINGLEJOYCON:
-                    for (int i = 0; i < PLAYER_MAX; i++) {
+                    if (!hidGetHandheldMode()) {
                         if (option->getValueInt() > 0) {
-                            hidSetNpadJoyAssignmentModeSingleByDefault((HidControllerID) i);
+                            for (int id = 0; id < 8; id++) {
+                                hidSetNpadJoyAssignmentModeSingleByDefault((HidControllerID) id);
+                            }
+                            hidSetNpadJoyHoldType(HidJoyHoldType_Horizontal);
+                            hidScanInput();
                         } else {
-                            hidSetNpadJoyAssignmentModeDual((HidControllerID) i);
+                            // find all left/right single JoyCon pairs and join them together
+                            for (int id = 0; id < 8; id++) {
+                                hidSetNpadJoyAssignmentModeDual((HidControllerID) id);
+                            }
+                            int lastRightId = 8;
+                            for (int id0 = 0; id0 < 8; id0++) {
+                                if (hidGetControllerType((HidControllerID) id0) & TYPE_JOYCON_LEFT) {
+                                    for (int id1 = lastRightId - 1; id1 >= 0; id1--) {
+                                        if (hidGetControllerType((HidControllerID) id1) & TYPE_JOYCON_RIGHT) {
+                                            lastRightId = id1;
+                                            // prevent missing player numbers
+                                            if (id0 < id1) {
+                                                hidMergeSingleJoyAsDualJoy((HidControllerID) id0, (HidControllerID) id1);
+                                            } else if (id0 > id1) {
+                                                hidMergeSingleJoyAsDualJoy((HidControllerID) id1, (HidControllerID) id0);
+                                            }
+                                            break;
+                                        }
+                                    }
+                                }
+                            }
                         }
                     }
                     break;


### PR DESCRIPTION
Without this PR, Psnes, Pnes and Pfba all crash when switching single joycon mode from off to on. 